### PR TITLE
docs: Update documentation instructions and add Clang basics

### DIFF
--- a/.github/instructions/documentation.instructions.md
+++ b/.github/instructions/documentation.instructions.md
@@ -70,7 +70,7 @@ Follow KISS (Keep It Simple Stupid):
 Avoid:
 
 - Promotional language or marketing speak
-- Unnecessary adjectives and adverbs  
+- Unnecessary adjectives and adverbs
 - Complex sentence structures
 - Assumptions about reader knowledge
 - Emoticons, emojis, and decorative punctuation

--- a/.github/instructions/documentation.instructions.md
+++ b/.github/instructions/documentation.instructions.md
@@ -9,11 +9,21 @@ decorative elements.
 
 ## Documentation Style
 
-- Use clear, concise language without flowery descriptions
-- Focus on actionable information and practical guidance
-- Provide specific examples and code snippets when relevant
-- Structure information hierarchically with proper headings
-- Use bullet points and numbered lists for clarity
+### Language Guidelines
+
+- **Concise**: Use short sentences. One concept per sentence.
+- **Simple**: Choose common words over complex alternatives.
+- **Descriptive**: State facts directly. Explain what, how, and why.
+- **Correct**: Verify all information. Test all code examples.
+- **Pedagogic**: Explain concepts step-by-step. Assume reader is learning.
+
+### Formatting Rules
+
+- **No decorative language**: Avoid adjectives like "amazing," "powerful," "seamless"
+- **No emoticons or emojis**: Professional tone only
+- **No em-dashes**: Use standard punctuation
+- **Structure hierarchically**: Use proper headings and lists
+- **Provide examples**: Include working code snippets
 
 ## Content Requirements
 
@@ -47,5 +57,20 @@ decorative elements.
 - Document validation and testing approaches
 - Include success metrics and evaluation criteria
 
-No decorative language, emoticons, or unnecessary pleasantries. Focus on information that enables successful implementation
-and usage.
+## Writing Principles
+
+Follow KISS (Keep It Simple Stupid):
+
+- **Be direct**: State what the reader needs to know
+- **Be practical**: Focus on implementation and usage
+- **Be helpful**: Solve real problems users face
+- **Be honest**: Document limitations and known issues
+- **Be consistent**: Use same terms and patterns throughout
+
+Avoid:
+
+- Promotional language or marketing speak
+- Unnecessary adjectives and adverbs  
+- Complex sentence structures
+- Assumptions about reader knowledge
+- Emoticons, emojis, and decorative punctuation

--- a/docs/clang/basics-clang.md
+++ b/docs/clang/basics-clang.md
@@ -1,0 +1,45 @@
+# Clang in DSP-JUCE
+
+This document explains how Clang is used for code formatting and quality enforcement in the DSP-JUCE project.
+
+## Purpose
+
+Clang provides automated code formatting and static analysis for C++ source files.
+It ensures consistent style and helps catch errors early.
+
+## Formatting with clang-format
+
+- The project uses a `.clang-format` file with LLVM-based style and project-specific adjustments.
+- All C++ source files (`src/*.cpp`, `src/*.h`) must be formatted before committing.
+- Line length is limited to 120 characters.
+- Consistent brace and indentation styles are enforced.
+
+**Format all files:**
+
+```bash
+clang-format -i src/*.cpp src/*.h
+```
+
+## Static Analysis
+
+- Clang provides comprehensive compiler warnings for early error detection.
+- Modern C++20 features are supported and recommended.
+- Platform-specific warning flags are enabled in `CMakeLists.txt`.
+
+## Integration
+
+- Formatting is required before every commit (see CONTRIBUTING.md).
+- CI/CD workflows verify code formatting and build correctness.
+- Clang is compatible with Visual Studio, Xcode, and Linux toolchains.
+
+## Troubleshooting
+
+- If formatting fails, check the `.clang-format` configuration.
+- Ensure Clang is installed and available in your system PATH.
+- For Windows, use the version bundled with Visual Studio or install via LLVM.
+
+## References
+
+- [Clang documentation](https://clang.llvm.org/docs/)
+- [LLVM project](https://llvm.org/)
+- See `.clang-format` in the project root for configuration details.

--- a/docs/clang/basics-clang.md
+++ b/docs/clang/basics-clang.md
@@ -38,6 +38,12 @@ clang-format -i src/*.cpp src/*.h
 - Ensure Clang is installed and available in your system PATH.
 - For Windows, use the version bundled with Visual Studio or install via LLVM.
 
+### Verifying Clang Installation
+
+To check if Clang is installed and available in your PATH, run:
+
+```bash
+clang --version
 ## References
 
 - [Clang documentation](https://clang.llvm.org/docs/)


### PR DESCRIPTION
- Enhance documentation.instructions.md with KISS principles and language guidelines
- Add docs/clang/basics-clang.md explaining Clang usage for formatting and analysis
- Emphasize concise, simple, pedagogic writing style
- Include practical examples and troubleshooting

Improves documentation quality and adds Clang tooling guidance.