### PR TITLE
Develop

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,14 +1,14 @@
-# DSP-JUCE Development Environment
+# JUCE Project Template Development Environment
 
-This repository is a modern JUCE 8.0.10 audio plugin development environment
-demonstrating real-time audio processing, cross-platform plugin builds, and modern C++20 patterns.
+This repository is a modern JUCE 8.0.10 audio plugin project template providing
+cross-platform build system, CI/CD integration, and fast development workflow patterns.
 
 ## Architecture Overview
 
 **Core Components:**
 
-- `src/MainComponent.h/cpp`: `DSPJuceAudioProcessor` implementing sine-wave synthesizer with thread-safe parameter control
-- `src/PluginEditor.h/cpp`: GUI editor with frequency/gain sliders using immediate parameter updates  
+- `src/MainComponent.h/cpp`: Example `DSPJuceAudioProcessor` demonstrating thread-safe parameter control
+- `src/PluginEditor.h/cpp`: Example GUI editor showing immediate parameter updates pattern
 - `src/Main.cpp`: Plugin entry point supporting both VST3 plugin and standalone builds
 - `CMakeLists.txt`: Modern CMake with FetchContent auto-downloading JUCE 8.0.10
 
@@ -58,9 +58,11 @@ cmake --build build/vs2022 --config Release  # Windows Release build
 
 **Output Locations (Windows vs2022 preset):**
 
-- VST3: `build/vs2022/JucePlugin_artefacts/Release/VST3/DSP-JUCE Plugin.vst3/`
-- Standalone: `build/vs2022/JucePlugin_artefacts/Release/Standalone/DSP-JUCE Plugin.exe`
-- Library: `build/vs2022/JucePlugin_artefacts/Release/DSP-JUCE Plugin_SharedCode.lib`
+- VST3: `build/vs2022/JucePlugin_artefacts/Release/VST3/Your Plugin.vst3/`
+- Standalone: `build/vs2022/JucePlugin_artefacts/Release/Standalone/Your Plugin.exe`
+- Library: `build/vs2022/JucePlugin_artefacts/Release/Your Plugin_SharedCode.lib`
+
+Note: Actual paths depend on PLUGIN_NAME set in CMakeLists.txt
 
 **Cross-Platform Presets:**
 
@@ -107,7 +109,7 @@ npm test                     # Validate documentation
   - `cmake-config.instructions.md`: CMake best practices for **/CMakeLists.txt
   - `documentation.instructions.md`: Markdown conventions for **/*.md
   - `github-config.instructions.md`: GitHub workflow patterns for .github/**/*
-- `build/vs2022/plugin_metadata.sh`: Auto-generated during CMake configure (sources plugin metadata)
+- `build/<preset>/plugin_metadata.sh`: Auto-generated during CMake configure (sources plugin metadata)
 
 **Code Patterns:**
 
@@ -159,13 +161,13 @@ style: Apply clang-format to source files
 ## Project Structure and Key Files
 
 ```text
-dsp-juce/
-├── src/                     # JUCE application source code
+juce-project-template/
+├── src/                     # Example plugin source code
 │   ├── Main.cpp            # Plugin entry point for both standalone and plugin formats
 │   ├── MainComponent.h     # AudioProcessor interface for audio processing
-│   ├── MainComponent.cpp   # Real-time audio processing with DSP
+│   ├── MainComponent.cpp   # Example real-time audio processing with DSP
 │   ├── PluginEditor.h      # AudioProcessorEditor interface for GUI
-│   └── PluginEditor.cpp    # GUI implementation with parameter controls
+│   └── PluginEditor.cpp    # Example GUI implementation with parameter controls
 ├── .github/                # GitHub configuration and instructions
 ├── CMakeLists.txt          # Modern CMake with JUCE 8.0.10 FetchContent
 ├── CMakePresets.json       # Cross-platform build presets

--- a/BUILD.md
+++ b/BUILD.md
@@ -92,9 +92,9 @@ ls -la build/JucePlugin_artefacts/Debug/
 
 Artefacts are in `build/JucePlugin_artefacts/<config>/`:
 
-- `VST3/DSP-JUCE Plugin.vst3` - VST3 plugin
-- `AU/DSP-JUCE Plugin.component` - AU plugin (macOS only)
-- `Standalone/DSP-JUCE Plugin[.exe|.app]` - Standalone application
+- `VST3/Your Plugin.vst3` - VST3 plugin
+- `AU/Your Plugin.component` - AU plugin (macOS only)
+- `Standalone/Your Plugin[.exe|.app]` - Standalone application
 
 Plugin file names use the `PLUGIN_NAME` variable defined in `CMakeLists.txt`. For example, setting
 `PLUGIN_NAME` to "MyPlugin" will produce artefacts like `VST3/MyPlugin.vst3`,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Contributing to DSP-JUCE
+# Contributing to JUCE Project Template
 
-Thank you for contributing to DSP-JUCE. This guide outlines the development workflow,
+Thank you for contributing to the JUCE Project Template. This guide outlines the development workflow,
 coding standards, and contribution process.
 
 ## Development Setup
@@ -16,7 +16,7 @@ coding standards, and contribution process.
 ```bash
 # Clone and configure
 git clone <your-fork-url>
-cd dsp-juce
+cd juce-project-template
 cmake --preset=default
 
 # Install documentation tools
@@ -214,10 +214,10 @@ cmake --preset=default && cmake --build --preset=default
 cmake --preset=release && cmake --build --preset=release
 
 # Test standalone application
-./build/JucePlugin_artefacts/Debug/Standalone/DSP-JUCE\ Plugin
+./build/JucePlugin_artefacts/Debug/Standalone/Your\ Plugin
 
 # Verify plugin installation (platform-specific)
-ls -la ~/.vst3/DSP-JUCE\ Plugin.vst3/  # Linux
+ls -la ~/.vst3/Your\ Plugin.vst3/  # Linux
 ```
 
 ### Performance Testing
@@ -283,6 +283,6 @@ npm run lint:md:fix
 
 ## Questions?
 
-- Open a [GitHub issue](https://github.com/KristofferKarlAxelEkstrand/dsp-juce/issues) for bugs or feature requests
+- Open a [GitHub issue](https://github.com/KristofferKarlAxelEkstrand/juce-project-template/issues) for bugs or feature requests
 - Check existing [documentation](docs/) for technical details
 - Review [JUCE examples](https://github.com/juce-framework/JUCE/tree/master/examples) for reference implementations

--- a/DEVELOPMENT_WORKFLOW.md
+++ b/DEVELOPMENT_WORKFLOW.md
@@ -20,7 +20,7 @@ Default build task. Press `Ctrl+Shift+B`.
 
 Runs: `./scripts/build-ninja.bat` (Windows) or `./scripts/build-ninja.sh` (macOS/Linux)
 
-Output: `build/ninja/JucePlugin_artefacts/Debug/Standalone/DSP-JUCE Plugin[.exe|.app]`
+Output: `build/ninja/JucePlugin_artefacts/Debug/Standalone/Your Plugin[.exe|.app]`
 
 ### 2. Run Standalone
 
@@ -174,7 +174,7 @@ Verifies:
 Plugin metadata is centralized in `CMakeLists.txt`:
 
 ```cmake
-set(PLUGIN_NAME "DSP-JUCE Plugin")
+set(PLUGIN_NAME "Your Plugin Name")
 set(PLUGIN_TARGET "JucePlugin")
 set(PLUGIN_VERSION "1.0.0")
 ```
@@ -235,7 +235,7 @@ Ninja should rebuild in 1-3 seconds for small changes. If slow:
 
 ### VST3 Plugin
 
-Built to: `build/ninja/JucePlugin_artefacts/Debug/VST3/DSP-JUCE Plugin.vst3/`
+Built to: `build/ninja/JucePlugin_artefacts/Debug/VST3/Your Plugin.vst3/`
 
 To test in a DAW:
 

--- a/README.md
+++ b/README.md
@@ -120,8 +120,8 @@ Two simple commands build everything:
 
 **Output location**: `build/JucePlugin_artefacts/Debug/`
 
-- `VST3/DSP-JUCE Plugin.vst3` - VST3 plugin
-- `Standalone/DSP-JUCE Plugin` - Standalone application
+- `VST3/Your Plugin.vst3` - VST3 plugin (name from PLUGIN_NAME in CMakeLists.txt)
+- `Standalone/Your Plugin` - Standalone application
 
 ### Customize Your Plugin
 

--- a/docs/CI_IMPLEMENTATION.md
+++ b/docs/CI_IMPLEMENTATION.md
@@ -346,6 +346,6 @@ c068fba docs: Update CI strategy for ultra-minimal develop
 **Next action:** Create test PR to develop branch to verify 3-job execution  
 **Confidence:** High - Implementation matches approved strategy exactly
 
-**Implemented by:** GitHub Copilot (Expert DSP-JUCE Development Assistant)  
+**Implemented by:** GitHub Copilot (JUCE Template Development Assistant)  
 **Date:** October 12, 2025  
 **Branch:** `feature/smarter-ci-runs` (commit 30f6b4e)

--- a/docs/CROSS_PLATFORM_BUILDS.md
+++ b/docs/CROSS_PLATFORM_BUILDS.md
@@ -65,9 +65,9 @@ VS Code selects the correct block based on OS.
 
 ### Executable Extensions
 
-- Windows: `DSP-JUCE Plugin.exe`
-- macOS: `DSP-JUCE Plugin.app` (application bundle)
-- Linux: `DSP-JUCE Plugin` (no extension)
+- Windows: `Your Plugin.exe`
+- macOS: `Your Plugin.app` (application bundle)
+- Linux: `Your Plugin` (no extension)
 
 ### Path Separators
 

--- a/docs/DESIGN_DECISIONS.md
+++ b/docs/DESIGN_DECISIONS.md
@@ -1,6 +1,6 @@
 # Design Decisions
 
-This document explains key architectural decisions in the DSP-JUCE project.
+This document explains key architectural decisions in the JUCE Project Template.
 
 ## Build Script Duplication vs. Shared Configuration
 

--- a/docs/VERSION_MANAGEMENT.md
+++ b/docs/VERSION_MANAGEMENT.md
@@ -82,7 +82,7 @@ Version from `CMakeLists.txt` flows to:
 | JUCE | `JucePlugin_VersionString` | "1.0.0" |
 | Metadata | `PROJECT_VERSION` | `export PROJECT_VERSION="1.0.0"` |
 | CI/CD | `$PROJECT_VERSION` | Workflow variable |
-| ZIP | Sanitized in workflow | `DSP-JUCE-Plugin-v1.0.0-windows.zip` |
+| ZIP | Sanitized in workflow | `Your-Plugin-v1.0.0-windows.zip` |
 | DAW | Plugin info | Displayed in DAW |
 
 ## Check Current Version
@@ -91,7 +91,7 @@ Version from `CMakeLists.txt` flows to:
 
 ```bash
 cmake --preset=default | grep "Plugin:"
-# Output: -- Plugin: DSP-JUCE Plugin v1.0.0
+# Output: -- Plugin: Your Plugin v1.0.0
 ```
 
 ### Metadata File

--- a/docs/clang/basics-clang.md
+++ b/docs/clang/basics-clang.md
@@ -1,6 +1,6 @@
-# Clang in DSP-JUCE
+# Clang in JUCE Project Template
 
-This document explains how Clang is used for code formatting and quality enforcement in the DSP-JUCE project.
+This document explains how Clang is used for code formatting and quality enforcement in this JUCE project template.
 
 ## Purpose
 

--- a/docs/cmake/basics-cmake.md
+++ b/docs/cmake/basics-cmake.md
@@ -38,7 +38,7 @@ FetchContent_Declare(JUCE
 # Configure plugin formats and properties
 juce_add_plugin(JucePlugin  # Plugin target name (from PLUGIN_TARGET variable)
     FORMATS VST3 AU Standalone
-    PRODUCT_NAME "DSP-JUCE Plugin")
+    PRODUCT_NAME "Your Plugin Name")
 ```
 
 **Modern CMake Benefits**:

--- a/plugin-development-roadmap.md
+++ b/plugin-development-roadmap.md
@@ -1,7 +1,10 @@
 # Plugin Development Roadmap: From Template to Feature-Complete Plugin
 
-This document outlines the plan for evolving the DSP-JUCE project from a foundational template into a
+This document outlines the plan for evolving your plugin from this JUCE project template into a
 functional audio plugin with a proper GUI, advanced DSP features, and robust testing.
+
+Note: This roadmap is for plugin developers using this template. The template itself provides
+the build system, CI/CD, and development workflow foundation.
 
 ---
 

--- a/scripts/test-builds.sh
+++ b/scripts/test-builds.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 
-# DSP-JUCE Build Testing Script
+# JUCE Project Template Build Testing Script
 # Tests that plugin and standalone builds work correctly
 
 set -e
 
-echo "DSP-JUCE Build Testing"
-echo "======================"
+echo "JUCE Project Template Build Testing"
+echo "===================================="
 echo
 
 # Determine build configuration: default to Debug if not specified

--- a/scripts/validate-builds.sh
+++ b/scripts/validate-builds.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 
-# DSP-JUCE Build Validation Script
+# JUCE Project Template Build Validation Script
 # Validates that plugin and standalone builds exist.
 
 set -e
 
-echo "DSP-JUCE Build Validation"
-echo "=========================="
+echo "JUCE Project Template Build Validation"
+echo "======================================="
 echo
 
 # --- Configuration ---

--- a/src/MainComponent.h
+++ b/src/MainComponent.h
@@ -6,7 +6,7 @@
 /**
  * @brief AudioProcessor for both plugin and standalone builds
  *
- * This processor provides a simple audio synthesizer with frequency and gain controls.
+ * This processor provides an example audio synthesizer with frequency and gain controls.
  * It demonstrates modern JUCE patterns including:
  * - Real-time audio processing with juce::dsp modules
  * - Thread-safe parameter handling between GUI and audio threads

--- a/src/PluginEditor.h
+++ b/src/PluginEditor.h
@@ -5,9 +5,9 @@
 #include <juce_gui_basics/juce_gui_basics.h>
 
 /**
- * @brief AudioProcessorEditor for the DSP-JUCE plugin
+ * @brief AudioProcessorEditor for JUCE plugin template
  *
- * This editor provides a GUI for controlling the audio processor parameters.
+ * This editor provides an example GUI for controlling audio processor parameters.
  * It demonstrates modern JUCE patterns including:
  * - Thread-safe parameter control between GUI and audio threads
  * - Modern visual design with gradients and proper spacing


### PR DESCRIPTION
This pull request updates the project to use a more generic "JUCE Project Template" branding, replacing previous "DSP-JUCE" references throughout documentation, build instructions, and metadata. The changes clarify that this repository is intended as a reusable, professional template for JUCE plugin development, and improve instructions for customizing plugin names and metadata via `CMakeLists.txt`. The documentation is also expanded to better explain template features, recommended workflows, and the rationale for using CMake over other approaches.

**Branding and Naming Updates**
* Replaced all instances of "DSP-JUCE" with "JUCE Project Template" or "Your Plugin" in documentation, build outputs, and metadata references across files such as `README.md`, `.github/copilot-instructions.md`, `CONTRIBUTING.md`, `BUILD.md`, and others. This includes directory names, file names, and example outputs, making the template more generic and customizable. [[1]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L1-R11) [[2]](diffhunk://#diff-40f60e1037245d7b8a98a7325d53890a717da9979adeb54a61a795c4ba07f9c9L95-R97) [[3]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L1-R3) [[4]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L19-R19) [[5]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L217-R220) [[6]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L286-R286) [[7]](diffhunk://#diff-ba58ebb1e155cfc84ebdc5a636555b009d59b33319e1b8dd50e792e43c9ca583L23-R23) [[8]](diffhunk://#diff-ba58ebb1e155cfc84ebdc5a636555b009d59b33319e1b8dd50e792e43c9ca583L177-R177) [[9]](diffhunk://#diff-ba58ebb1e155cfc84ebdc5a636555b009d59b33319e1b8dd50e792e43c9ca583L238-R238) [[10]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-R277) [[11]](diffhunk://#diff-fa8f5d6f79b6f4c5bae3342f7eb1c6bd3b01eff5bf01e34b9844e302cecbdca8L68-R70) [[12]](diffhunk://#diff-7addb44dcf4ce30be0257bc7596df84869eff55224ca0c36ee2830cd1c62153cL3-R3) [[13]](diffhunk://#diff-a17cbb63faf22fd472549fbe14c5eca42dae622b2d3de2a00b3f56375b744a42L85-R85) [[14]](diffhunk://#diff-a17cbb63faf22fd472549fbe14c5eca42dae622b2d3de2a00b3f56375b744a42L94-R94)

**Documentation Improvements**
* Expanded the `README.md` to provide a comprehensive overview of the template, including its features, recommended workflows, rationale for CMake-based development, and step-by-step instructions for setup, customization, and building plugins.
* Updated `.github/copilot-instructions.md` and other guides to clarify the architecture, output locations, and how to customize plugin names and metadata using `CMakeLists.txt`. [[1]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L61-R65) [[2]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L110-R112) [[3]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L162-R170)

**Contribution and Workflow Guidance**
* Revised `CONTRIBUTING.md` to reflect the new repository name, update clone instructions, and point issue reporting to the new GitHub URL. [[1]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L1-R3) [[2]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L19-R19) [[3]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L286-R286)
* Updated development workflow documentation to use the new plugin naming conventions and clarify build/test procedures. [[1]](diffhunk://#diff-ba58ebb1e155cfc84ebdc5a636555b009d59b33319e1b8dd50e792e43c9ca583L23-R23) [[2]](diffhunk://#diff-ba58ebb1e155cfc84ebdc5a636555b009d59b33319e1b8dd50e792e43c9ca583L177-R177) [[3]](diffhunk://#diff-ba58ebb1e155cfc84ebdc5a636555b009d59b33319e1b8dd50e792e43c9ca583L238-R238)

**Metadata and Versioning**
* Standardized plugin metadata management by instructing users to edit `PLUGIN_NAME` and related variables in `CMakeLists.txt`, ensuring build outputs and documentation reflect custom plugin branding. [[1]](diffhunk://#diff-40f60e1037245d7b8a98a7325d53890a717da9979adeb54a61a795c4ba07f9c9L95-R97) [[2]](diffhunk://#diff-a17cbb63faf22fd472549fbe14c5eca42dae622b2d3de2a00b3f56375b744a42L85-R85) [[3]](diffhunk://#diff-a17cbb63faf22fd472549fbe14c5eca42dae622b2d3de2a00b3f56375b744a42L94-R94)

**Miscellaneous Updates**
* Updated references to the Copilot assistant and other minor details to match the new template branding.